### PR TITLE
Refactor division references and fix minor typos

### DIFF
--- a/app/Http/Controllers/Masterlist/MasterlistExportController.php
+++ b/app/Http/Controllers/Masterlist/MasterlistExportController.php
@@ -114,7 +114,6 @@ class MasterlistExportController extends Controller
             'formula' => function ($query) {
                 $query->withTrashed();
             },
-            'division:id,division_name',
             'majorCategory:id,major_category_name',
             'minorCategory:id,minor_category_name',
         ]);
@@ -144,7 +143,7 @@ class MasterlistExportController extends Controller
                 $query->orWhereHas('minorCategory', function ($query) use ($search) {
                     $query->withTrashed()->where('minor_category_name', 'LIKE', '%' . $search . '%');
                 });
-                $query->orWhereHas('division', function ($query) use ($search) {
+                $query->orWhereHas('department.division', function ($query) use ($search) {
                     $query->withTrashed()->where('division_name', 'LIKE', '%' . $search . '%');
                 });
                 $query->orWhereHas('assetStatus', function ($query) use ($search) {
@@ -207,7 +206,7 @@ class MasterlistExportController extends Controller
                 'accountability' => $fixed_asset->accountability,
                 'accountable' => $fixed_asset->accountable,
                 'brand' => $fixed_asset->brand,
-                'division' => $fixed_asset->division->division_name,
+                'division' => $fixed_asset->department->division->division_name,
                 'major_category' => $fixed_asset->majorCategory->major_category_name,
                 'minor_category' => $fixed_asset->minorCategory->minor_category_name,
                 'capitalized' => $fixed_asset->capitalized,

--- a/app/Imports/MasterlistImport.php
+++ b/app/Imports/MasterlistImport.php
@@ -72,6 +72,37 @@ class MasterlistImport extends DefaultValueBinder implements
 
     public function collection(Collection $collections)
     {
+
+//        $client = new Client();
+//        $token = '9|u27KMjj3ogv0hUR8MMskyNmhDJ9Q8IwUJRg8KAZ4';
+//        $response = $client->request('GET', 'http://rdfsedar.com/api/data/employees', [
+//            'headers' => [
+//                'Authorization' => 'Bearer ' . $token,
+//                'Accept' => 'application/json',
+//            ],
+//        ]);
+//
+//// Get the body content from the response
+//        $body = $response->getBody()->getContents();
+//
+//// Decode the JSON response into an associative array
+//        $data = json_decode($body, true);
+//        $nameToCheck = [
+//            'Perona, jerome',
+//            'Dela Rosa, Justine',
+//            'Nucum, Caren'
+//        ];
+//
+//        if (!empty($data['data']) && is_array($data['data'])) {
+//            foreach ($data['data'] as $employee) {
+//                if (!empty($employee['general_info']) && in_array($employee['general_info']['full_name'], $nameToCheck)) {
+//                    echo $employee['general_info']['full_id_number'] . PHP_EOL;
+//                    break;
+//                }
+//            }
+//        }
+
+
         Validator::make($collections->toArray(), $this->rules($collections->toArray()), $this->messages())->validate();
 
         foreach ($collections as $collection) {
@@ -302,7 +333,7 @@ class MasterlistImport extends DefaultValueBinder implements
 //                function ($attribute, $value, $fail) use ($collections) {
 //                    $major_category = MajorCategory::withTrashed()->where('major_category_name', $value)->first();
 //                    if (!$major_category) {
-//                        $fail('Major Category does not exists');
+//                        $fail('Major Category does not exist');
 //                    }
 //                }
             ],
@@ -511,5 +542,23 @@ class MasterlistImport extends DefaultValueBinder implements
         $generated = [];
         return in_array($ean13Result, $generated) || FixedAsset::where('vladimir_tag_number', $ean13Result)->exists();
     }
+    function getEmployeeData($client, $token){
+        return $client->request('GET', 'http://rdfsedar.com/api/data/employees', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Accept' => 'application/json',
+            ],
+        ])->getBody()->getContents();
+    }
 
+    function findEmployee($data, $value){
+        if (!empty($data['data']) && is_array($data['data'])) {
+            foreach ($data['data'] as $employee) {
+                if (!empty($employee['general_info']) && in_array($employee['general_info']['full_name'], $value)) {
+                    echo $employee['general_info']['full_id_number'] . PHP_EOL;
+                    break;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This commit addresses some changes in the MasterlistExportController and MasterlistImport files. Primarily, it refines how the app references divisions - instead of attempting to reach it directly, it does so through a related department attribute. This ensures we still get the division_name even if the division object is null.

Though a minor change, it adds up to the overall user experience as it helps prevent possible crashes and improves data consistency.

Furthermore, some typos noticed in the comments in the MasterlistImport class have been fixed for clarity and readability. Recommended functions are also added to retrieve and find employee data.